### PR TITLE
Add a compile-fail test for heap crossing in the other direction

### DIFF
--- a/tests/compile-fail/cross-heap-edge-alloc-2.rs
+++ b/tests/compile-fail/cross-heap-edge-alloc-2.rs
@@ -1,0 +1,17 @@
+//! Same as `cross-heap-edge-alloc.rs` but crossing the other direction.
+
+#[macro_use] extern crate cell_gc;
+#[macro_use] extern crate cell_gc_derive;
+mod pairs_aux;
+use cell_gc::*;
+use pairs_aux::*;
+
+fn main() {
+    with_heap(|heap1| {
+        with_heap(|heap2| {
+            let obj2 = alloc_null_pair(heap2);
+            //~^ ERROR cannot infer an appropriate lifetime for lifetime parameter 'h in function call due to conflicting requirements
+            let obj1 = alloc_pair(heap1, Value::Null, Value::Pair(obj2));
+        });
+    });
+}


### PR DESCRIPTION
I'm mildly surprised this test passes. The explanation that `for <'a>` in the
`with_heap` signature means that it "breaks" the lifetime subtyping here makes
sense to me, but I'd need to dig in deeper to fully get it...